### PR TITLE
Add cf-template to deploy ec2-proxysql and Modify original one to build

### DIFF
--- a/1_reverse_proxy/README.md
+++ b/1_reverse_proxy/README.md
@@ -1,17 +1,60 @@
 # ProxySQL
-The command to run cloudforatmion 
+1. The command to run build-template to initialize ec2 with proxysql 
 ```bash
 aws cloudformation create-stack --region us-west-2 \
   --stack-name proxysql-$(date +%d%H%M%S) \
-  --template-body file://ec2-proxysql.yaml \
+  --template-body file://ec2-proxysql-build.yaml \
   --parameters \
-    ParameterKey="KeyName",ParameterValue="KeyName" \
-    ParameterKey="PubKey",ParameterValue="PubKey" \
-    ParameterKey="SGIngressSSH",ParameterValue="SGID" \
-    ParameterKey="VpcId",ParameterValue="VpcId" \
-    ParameterKey="SubnetId",ParameterValue="SubnetId"
+    ParameterKey="KeyName",ParameterValue="KEY NAME" \
+    ParameterKey="PubKey",ParameterValue="PUBLIC KEY" \
+    ParameterKey="SGIngressSSH",ParameterValue="SECURITY GROUP ID" \
+    ParameterKey="OSUser",ParameterValue="OS USER NAME" \
+    ParameterKey="VpcId",ParameterValue="VPC ID" \
+    ParameterKey="SubnetId",ParameterValue="SUBNET ID"
 ```
-The policy to grant for creating stack
+2. Getting id of EC2 Inatance which made by previous step
+```bash
+> aws cloudformation describe-stack-resource --region us-west-2 \
+--stack-name CLOUD STACK NAME \
+--logical-resource-id EC2Instance
+
+Output might be:
+{
+    "StackResourceDetail": {
+        "StackId": "arn:aws:cloudformation:us-west-2:123456789101:stack/STACK NAME/ee", 
+        "ResourceStatus": "CREATE_COMPLETE", 
+        "DriftInformation": {
+            "StackResourceDriftStatus": "NOT_CHECKED"
+        }, 
+        "ResourceType": "AWS::EC2::Instance", 
+        "LastUpdatedTimestamp": "2020-03-20T05:16:46.560Z", 
+        "StackName": "STACK NAME", 
+        "PhysicalResourceId": "i-0abcdabcd12345678", 
+        "Metadata": "{}", 
+        "LogicalResourceId": "EC2Instance"
+    }
+}
+
+# Then create AMI
+> aws ec2 create-image --region us-west-2 \
+--no-dry-run --reboot \
+--instance-id i-0abcdabcd12345678 --name proxysql
+
+```
+2. Getting id of EC2 Inatance which made by previous step
+```bash
+aws cloudformation create-stack --region us-west-2 \
+  --stack-name proxysql-$(date +%d%H%M%S) \
+  --template-body file://ec2-proxysql-deploy.yaml \
+  --parameters \
+    ParameterKey="SGIngressSSH",ParameterValue="SECURITY GROUP ID" \
+    ParameterKey="AZ1SubnetId",ParameterValue="SUBNET ID" \
+    ParameterKey="AZ2SubnetId",ParameterValue="SUBNET ID" \
+    ParameterKey="VpcId",ParameterValue="VPC ID" \
+    ParameterKey="AMI",ParameterValue="AMI ID"
+```
+
+The policy have to be granted for executing cloudformation
 ```json
 {
     "Version": "2012-10-17",
@@ -27,7 +70,9 @@ The policy to grant for creating stack
                 "ec2:DescribeInstances",
                 "ec2:DescribeAddresses",
                 "ec2:TerminateInstances",
+                "ec2:CreateImage",
                 "ec2:RunInstances",
+                "cloudformation:DescribeStackResource",
                 "ssm:GetParameters",
                 "ec2:DescribeSecurityGroups",
                 "ec2:AllocateAddress",
@@ -35,6 +80,7 @@ The policy to grant for creating stack
                 "cloudformation:CreateStack",
                 "ec2:DescribeVpcs",
                 "ec2:CreateSecurityGroup",
+                "cloudformation:DeleteStack",
                 "ec2:DeleteSecurityGroup",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeKeyPairs",

--- a/1_reverse_proxy/ec2-proxysql-build.yaml
+++ b/1_reverse_proxy/ec2-proxysql-build.yaml
@@ -11,6 +11,11 @@ Parameters:
     Description: ID of an existing Security Group to allow ssh connection
     Type: 'AWS::EC2::SecurityGroup::Id'
     ConstraintDescription: Security Group ID doesn't exist
+  OSUser:
+    Description: User name which will allow to login through ssh
+    Type: String
+    AllowedPattern: '[a-z_][a-z0-9_-]*[$]?'
+    # https://www.unix.com/man-page/linux/8/useradd/
   VpcId:
     Description: ID of an existing VPC
     Type:  'AWS::EC2::VPC::Id'
@@ -42,15 +47,17 @@ Resources:
         Fn::Base64:
           !Sub |
             #!/bin/bash -x
-            adduser --user-group cfuser
-            mkdir /home/cfuser/.ssh
-            chmod 700 /home/cfuser/.ssh
-            touch /home/cfuser/.ssh/authorized_keys
-            chmod 600 /home/cfuser/.ssh/authorized_keys
-            chown -R cfuser:cfuser /home/cfuser/.ssh
-            echo ${PubKey} >> /home/cfuser/.ssh/authorized_keys
-            touch /etc/sudoers.d/cfuser
-            echo 'cfuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/cfuser
+            adduser --user-group ${OSUser}
+            mkdir /home/${OSUser}/.ssh
+            chmod 700 /home/${OSUser}/.ssh
+            touch /home/${OSUser}/.ssh/authorized_keys
+            chmod 600 /home/${OSUser}/.ssh/authorized_keys
+            chown -R ${OSUser}:${OSUser} /home/${OSUser}/.ssh
+            echo ${PubKey} >> /home/${OSUser}/.ssh/authorized_keys
+            cat /home/ec2-user/.ssh/authorized_keys >> /home/${OSUser}/.ssh/authorized_keys
+            userdel --remove ec2-user
+            touch /etc/sudoers.d/${OSUser}
+            echo '${OSUser} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/${OSUser}
             sed -i 's/#Port 22/Port 40022/g' /etc/ssh/sshd_config
             systemctl restart sshd
             cat <<EOF | tee /etc/yum.repos.d/proxysql.repo
@@ -76,3 +83,7 @@ Resources:
     Properties:
       Domain: vpc
       InstanceId: !Ref EC2Instance
+Outputs:
+  Ec2PproxysqlId: 
+    Description: Instance ID ec2-proxysql
+    Value: !Ref EC2Instance

--- a/1_reverse_proxy/ec2-proxysql-deploy.yaml
+++ b/1_reverse_proxy/ec2-proxysql-deploy.yaml
@@ -1,0 +1,55 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  SGIngressSSH:
+    Description: ID of an existing Security Group to allow ssh connection
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    ConstraintDescription: Security Group ID doesn't exist
+  VpcId:
+    Description: ID of an existing VPC
+    Type:  'AWS::EC2::VPC::Id'
+    ConstraintDescription: VPC ID doesn't exist
+  AZ1SubnetId:
+    Description: ID of an existing SubnetId
+    Type:  'AWS::EC2::Subnet::Id'
+    ConstraintDescription: Subnet ID doesn't exist
+  AZ2SubnetId:
+    Description: ID of an existing SubnetId
+    Type:  'AWS::EC2::Subnet::Id'
+    ConstraintDescription: Subnet ID doesn't exist
+  InstanceType:
+    AllowedValues:
+    - t3.micro
+    Default: t3.micro
+    Type: String
+    Description: EC2 instance type. t3.micro is only acceptable type of instance
+  AMI:
+    Description: ID of an existing SubnetId
+    Type:  'AWS::EC2::Image::Id'
+    ConstraintDescription: AMI ID doesn't exist
+Resources:
+  Instance1:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      InstanceType: !Ref 'InstanceType'
+      ImageId: !Ref 'AMI'
+      SubnetId: !Ref 'AZ1SubnetId'
+      SecurityGroupIds: 
+        - !GetAtt ProxySQLSecurityGroup.GroupId
+  Instance2:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      InstanceType: !Ref 'InstanceType'
+      ImageId: !Ref 'AMI'
+      SubnetId: !Ref 'AZ2SubnetId'
+      SecurityGroupIds: 
+        - !GetAtt ProxySQLSecurityGroup.GroupId
+  ProxySQLSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via custom port and specific source
+      VpcId: !Ref 'VpcId'
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        SourceSecurityGroupId: !Ref 'SGIngressSSH'
+        FromPort: 40022
+        ToPort: 40022


### PR DESCRIPTION
It is to make a procedures of ec2-proxysql as multiple phases.
1. Initializing proxysql on the ec2 in the temporary subnet which has faced Internet
2. Creating AMI
3. Deploying proxysql instance using AMI in the target subnet
It will be integrated with some method like abstracting but for now it would be run manually.