### PR TITLE
Generating proxysql.cnf in USER_DATA of ec2

### DIFF
--- a/1_reverse_proxy/README.md
+++ b/1_reverse_proxy/README.md
@@ -2,15 +2,17 @@
 1. The command to run build-template to initialize ec2 with proxysql 
 ```bash
 aws cloudformation create-stack --region us-west-2 \
-  --stack-name proxysql-$(date +%d%H%M%S) \
-  --template-body file://ec2-proxysql-build.yaml \
-  --parameters \
-    ParameterKey="KeyName",ParameterValue="KEY NAME" \
-    ParameterKey="PubKey",ParameterValue="PUBLIC KEY" \
-    ParameterKey="SGIngressSSH",ParameterValue="SECURITY GROUP ID" \
-    ParameterKey="OSUser",ParameterValue="OS USER NAME" \
-    ParameterKey="VpcId",ParameterValue="VPC ID" \
-    ParameterKey="SubnetId",ParameterValue="SUBNET ID"
+--stack-name proxysql-$(date +%d%H%M%S) \
+--template-body file://ec2-proxysql-build.yaml \
+--parameters \
+  ParameterKey="KeyName",ParameterValue="{KEY_NAME}" \
+  ParameterKey="PubKey",ParameterValue="{PUBLIC_KEY}" \
+  ParameterKey="SGIngressSSH",ParameterValue="{SSH_INGRESS_SECURITY_GROUP_ID}" \
+  ParameterKey="OSUser",ParameterValue="{OS_USER_NAME}" \
+  ParameterKey="VpcId",ParameterValue="{VPC_ID}" \
+  ParameterKey="SubnetId",ParameterValue="{SUBNET_ID}" \
+  ParameterKey="MySQLEndpoints",ParameterValue=`aws rds describe-db-instances --region {REGION} --filters Name=db-cluster-id,Values={DB_CLUSTER_ID} --query 'DBInstances[*].Endpoint.Address' --output text| sed 's/\t/\;/'`
+
 ```
 2. Getting id of EC2 Inatance which made by previous step
 ```bash
@@ -67,8 +69,8 @@ The policy have to be granted for executing cloudformation
                 "ec2:DisassociateAddress",
                 "ec2:AuthorizeSecurityGroupEgress",
                 "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:DescribeInstances",
                 "ec2:DescribeAddresses",
+                "ec2:DescribeInstances",
                 "ec2:TerminateInstances",
                 "ec2:CreateImage",
                 "ec2:RunInstances",
@@ -82,6 +84,7 @@ The policy have to be granted for executing cloudformation
                 "ec2:CreateSecurityGroup",
                 "cloudformation:DeleteStack",
                 "ec2:DeleteSecurityGroup",
+                "rds:DescribeDBInstances",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeKeyPairs",
                 "ec2:AssociateAddress"

--- a/1_reverse_proxy/ec2-proxysql-build.yaml
+++ b/1_reverse_proxy/ec2-proxysql-build.yaml
@@ -33,6 +33,9 @@ Parameters:
   LatestAmiId:
     Type:  'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+  MySQLEndpoints:
+    Description: DB Cluster ID which is gonna have target server on proxysql
+    Type: String
 Resources:
   EC2Instance:
     Type: 'AWS::EC2::Instance'
@@ -47,6 +50,7 @@ Resources:
         Fn::Base64:
           !Sub |
             #!/bin/bash -x
+            printf "user setting"
             adduser --user-group ${OSUser}
             mkdir /home/${OSUser}/.ssh
             chmod 700 /home/${OSUser}/.ssh
@@ -58,8 +62,10 @@ Resources:
             userdel --remove ec2-user
             touch /etc/sudoers.d/${OSUser}
             echo '${OSUser} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/${OSUser}
+            printf "ssh setting"
             sed -i 's/#Port 22/Port 40022/g' /etc/ssh/sshd_config
             systemctl restart sshd
+            printf "install proxysql"
             cat <<EOF | tee /etc/yum.repos.d/proxysql.repo
             [proxysql_repo]
             name= ProxySQL YUM repository
@@ -68,10 +74,9 @@ Resources:
             gpgkey=https://repo.proxysql.com/ProxySQL/repo_pub_key
             EOF
             yum install -y proxysql-2.0.8-1
-            mkdir /opt/proxysql
-            chown -R proxysql:proxysql /opt/proxysql
+            printf "configure proxysql"
             cat <<EOF | tee /etc/proxysql.cnf
-            datadir="/opt/proxysql"
+            datadir="/var/lib/proxysql"
             admin_variables=
             {
              	admin_credentials="${OSUser}:admin"
@@ -87,10 +92,10 @@ Resources:
             	default_query_timeout=36000000
             	have_compress=true
             	poll_timeout=2000
-            	interfaces="0.0.0.0:43306;/opt/proxysql/proxysql.sock"
+            	interfaces="0.0.0.0:43306;0.0.0.0:43307"
             	default_schema="information_schema"
             	stacksize=1048576
-            	server_version="5.7"
+            	server_version="5.7.12"
             	connect_timeout_server=3000
             	monitor_username="monitor"
             	monitor_password="monitor"
@@ -105,11 +110,67 @@ Resources:
             	sessions_sort=true
             	connect_retries_on_failure=10
             }
+            mysql_users:
+            (
+            	{
+            		username = "my${OSUser}"
+            		password = "my${OSUser}"
+            		default_hostgroup = 1
+            	}
+            )
+            mysql_query_rules:
+            (
+            	{
+            		rule_id=1
+            		active=1
+            		proxy_port = 43306
+            		destination_hostgroup=1
+            		apply=1
+            	},
+            	{
+            		rule_id=2
+            		active=1
+            		proxy_port = 43307
+            		destination_hostgroup=2
+            		apply=1
+            	}
+            )
+            mysql_replication_hostgroups=
+            (
+            	{
+            		writer_hostgroup=1
+            		reader_hostgroup=2
+            		check_type="innodb_read_only"
+            	}
+            )
             EOF
+            cat <<EOF | tee /root/configen.tmp
+            #!/bin/bash
+            IFS=';'
+            body="mysql_servers =\n(%s)"
+            server="\t{\n\t\thostgroup = %s\n\t\taddress = \"%s\"\n\t\tport = 43306\n\t}"
+            mysql_servers=""
+            delimiter=","
+            read -ra endpoint_arr <<< "$ ESC 1"
+            length=$ ESC (($ ESC {#endpoint_arr[@]}-1));
+            for i in "$ ESC {!endpoint_arr[@]}"
+            do
+              mysql_servers=$ ESC mysql_servers$ ESC (printf $ ESC server '1' $ ESC {endpoint_arr[i]})$ ESC delimiter$ ESC '\n'
+              if [ $ ESC i -eq $ ESC length ]
+              then
+                delimiter=""
+              fi
+              mysql_servers=$ ESC mysql_servers$ ESC (printf $ ESC server '2' $ ESC {endpoint_arr[i]})$ ESC delimiter$ ESC '\n'
+            done
+            printf $ ESC body $ ESC '\n'$ ESC mysql_servers
+            EOF
+            sed 's/ ESC //g' /root/configen.tmp > /root/configen.sh
+            chmod +x /root/configen.sh
+            /root/configen.sh '${MySQLEndpoints}' >> /etc/proxysql.cnf
   ProxySQLSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Enable SSH access via custom port and specific source
+      GroupDescription: ProxySQL Security Group
       VpcId: !Ref 'VpcId'
       SecurityGroupIngress:
       - IpProtocol: tcp
@@ -121,7 +182,3 @@ Resources:
     Properties:
       Domain: vpc
       InstanceId: !Ref EC2Instance
-Outputs:
-  Ec2PproxysqlId: 
-    Description: Instance ID ec2-proxysql
-    Value: !Ref EC2Instance

--- a/1_reverse_proxy/ec2-proxysql-build.yaml
+++ b/1_reverse_proxy/ec2-proxysql-build.yaml
@@ -4,18 +4,18 @@ Parameters:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
     Type: 'AWS::EC2::KeyPair::KeyName'
     ConstraintDescription: key name doesn't exist
-  PubKey:
-    Description: Public Key for secuser
-    Type: String
-  SGIngressSSH:
-    Description: ID of an existing Security Group to allow ssh connection
-    Type: 'AWS::EC2::SecurityGroup::Id'
-    ConstraintDescription: Security Group ID doesn't exist
   OSUser:
     Description: User name which will allow to login through ssh
     Type: String
     AllowedPattern: '[a-z_][a-z0-9_-]*[$]?'
     # https://www.unix.com/man-page/linux/8/useradd/
+  PubKey:
+    Description: Public Key for OSUser
+    Type: String
+  SGIngressSSH:
+    Description: ID of an existing Security Group to allow ssh connection
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    ConstraintDescription: Security Group ID doesn't exist
   VpcId:
     Description: ID of an existing VPC
     Type:  'AWS::EC2::VPC::Id'
@@ -68,6 +68,44 @@ Resources:
             gpgkey=https://repo.proxysql.com/ProxySQL/repo_pub_key
             EOF
             yum install -y proxysql-2.0.8-1
+            mkdir /opt/proxysql
+            chown -R proxysql:proxysql /opt/proxysql
+            cat <<EOF | tee /etc/proxysql.cnf
+            datadir="/opt/proxysql"
+            admin_variables=
+            {
+             	admin_credentials="${OSUser}:admin"
+            	mysql_ifaces="0.0.0.0:46032"
+            	refresh_interval=2000
+            	debug=false
+            }
+            mysql_variables=
+            {
+            	threads=4
+            	max_connections=2048
+            	default_query_delay=0
+            	default_query_timeout=36000000
+            	have_compress=true
+            	poll_timeout=2000
+            	interfaces="0.0.0.0:43306;/opt/proxysql/proxysql.sock"
+            	default_schema="information_schema"
+            	stacksize=1048576
+            	server_version="5.7"
+            	connect_timeout_server=3000
+            	monitor_username="monitor"
+            	monitor_password="monitor"
+            	monitor_history=600000
+            	monitor_connect_interval=60000
+            	monitor_ping_interval=10000
+            	monitor_read_only_interval=1500
+            	monitor_read_only_timeout=500
+            	ping_interval_server_msec=120000
+            	ping_timeout_server=500
+            	commands_stats=true
+            	sessions_sort=true
+            	connect_retries_on_failure=10
+            }
+            EOF
   ProxySQLSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
Through injecting a script to generate configuration of proxysql into the step of initializing ec2(USER_DATA) so that to make proxysql ready to work properly without manul something.

One thing I'd like to inform that about dollar character in USER_DATA, it will resolve to some unexpected value inside of the VM so that I didn't get complete script to work. There have some hack to address this. I've marked it as ' ECS ' and then added a step to remove it. As a result I've got it as expected as following:
`length=$ ESC (($ ESC {#endpoint_arr[@]}-1));` -> `length=$((${#endpoint_arr[@]}-1));`